### PR TITLE
Home Assistant MQTT support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4fa78e18c64fce05e902adecd7a5eed15a5e0a3439f7b0e169f0252214865e3"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10,12 +19,18 @@ checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
 name = "aho-corasick"
-version = "0.7.20"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
 
 [[package]]
 name = "android_system_properties"
@@ -27,10 +42,81 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-trait"
-version = "0.1.60"
+name = "anstream"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d1d8ab452a3936018a687b20e6f7cf5363d713b732b8884001317b0e48aa3"
+checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is-terminal",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
+name = "async-stream"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-trait"
+version = "0.1.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a564d521dd56509c4c47480d00b80ee55f7e385ae48db5744c67ad50c92d2ebf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -50,10 +136,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b7e4c2464d97fe331d41de9d5db0def0a96f4d823b8b32a2efd503578988973"
 
 [[package]]
-name = "base64"
-version = "0.21.0"
+name = "backtrace"
+version = "0.3.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
+checksum = "4319208da049c43661739c5fade2ba182f09d1dc2299b32298d3a31692b17e12"
+dependencies = [
+ "addr2line",
+ "cc",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+]
+
+[[package]]
+name = "base64"
+version = "0.21.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
 
 [[package]]
 name = "bitflags"
@@ -62,10 +163,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
-name = "bumpalo"
-version = "3.11.1"
+name = "bitflags"
+version = "2.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+
+[[package]]
+name = "bumpalo"
+version = "3.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "bytemuck"
@@ -81,15 +188,15 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.3.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfb24e866b15a1af2a1b663f10c6b6b8f397a84aadb828f12e5b289ec23a3a3c"
+checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
 
 [[package]]
 name = "cc"
-version = "1.0.78"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a20104e2335ce8a659d6dd92a51a767a0c062599c73b343fd152cb401e828c3d"
+checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
 
 [[package]]
 name = "cfg-if"
@@ -99,14 +206,15 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.23"
+version = "0.4.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b0a3d9ed01224b22057780a37bb8c5dbfe1be8ba48678e7bf57ec4b385411f"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
- "num-integer",
  "num-traits",
+ "serde",
  "time",
  "wasm-bindgen",
  "winapi",
@@ -114,42 +222,43 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.1.1"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec7a4128863c188deefe750ac1d1dfe66c236909f845af04beed823638dc1b2"
+checksum = "3eab9e8ceb9afdade1ab3f0fd8dbce5b1b2f468ad653baf10e771781b2b67b73"
 dependencies = [
- "bitflags",
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f2763db829349bf00cfc06251268865ed4363b93a943174f638daf3ecdba2cd"
+dependencies = [
+ "anstream",
+ "anstyle",
  "clap_lex",
- "is-terminal",
  "once_cell",
  "strsim",
- "termcolor",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.3.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "783fe232adfca04f90f56201b26d79682d4cd2625e0bc7290b95123afe558ade"
-dependencies = [
- "os_str_bytes",
-]
-
-[[package]]
-name = "codespan-reporting"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
-dependencies = [
- "termcolor",
- "unicode-width",
-]
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "config"
@@ -177,9 +286,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+checksum = "e496a50fda8aacccc86d7529e2c1e0892dbd0f898a6b5645b5561b89c3210efa"
 
 [[package]]
 name = "crc32fast"
@@ -188,50 +297,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "cxx"
-version = "1.0.85"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add3fc1717409d029b20c5b6903fc0c0b02fa6741d820054f4a2efa5e5816fd"
-dependencies = [
- "cc",
- "cxxbridge-flags",
- "cxxbridge-macro",
- "link-cplusplus",
-]
-
-[[package]]
-name = "cxx-build"
-version = "1.0.85"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4c87959ba14bc6fbc61df77c3fcfe180fc32b93538c4f1031dd802ccb5f2ff0"
-dependencies = [
- "cc",
- "codespan-reporting",
- "once_cell",
- "proc-macro2",
- "quote",
- "scratch",
- "syn",
-]
-
-[[package]]
-name = "cxxbridge-flags"
-version = "1.0.85"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69a3e162fde4e594ed2b07d0f83c6c67b745e7f28ce58c6df5e6b6bef99dfb59"
-
-[[package]]
-name = "cxxbridge-macro"
-version = "1.0.85"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e7e2adeb6a0d4a282e581096b06e1791532b7d576dcde5ccd9382acf55db8e6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -270,20 +335,25 @@ dependencies = [
 name = "energy-monitor"
 version = "0.1.0"
 dependencies = [
+ "async-stream",
  "chrono",
  "clap",
  "config",
  "embedded-graphics",
  "env_logger",
+ "futures",
  "image",
  "lazy_static",
  "log",
  "openssl",
+ "regex",
  "reqwest",
  "rppal",
+ "rumqttc",
  "serde",
  "serde_json",
  "tokio",
+ "tokio-stream",
 ]
 
 [[package]]
@@ -301,13 +371,13 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.2.8"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
+checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
 dependencies = [
  "errno-dragonfly",
  "libc",
- "winapi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -358,6 +428,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "flume"
+version = "0.10.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "pin-project",
+ "spin 0.9.8",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,57 +463,126 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
+checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
 ]
 
 [[package]]
-name = "futures-channel"
-version = "0.3.26"
+name = "futures"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5317663a9089767a1ec00a487df42e0ca174b61b4483213ac24448e4664df5"
+checksum = "23342abe12aba583913b2e62f22225ff9c950774065e4bfb61a19cd9770fec40"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955518d47e09b25bbebc7a18df10b81f0c766eaf4c4f1cccef2fca5f2a4fb5f2"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.26"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec90ff4d0fe1f57d600049061dc6bb68ed03c7d2fbd697274c41805dcb3f8608"
+checksum = "4bca583b7e26f571124fe5b7561d49cb2868d79116cfa0eefce955557c6fee8c"
 
 [[package]]
-name = "futures-sink"
-version = "0.3.26"
+name = "futures-executor"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f310820bb3e8cfd46c80db4d7fb8353e15dfff853a127158425f31e0be6c8364"
-
-[[package]]
-name = "futures-task"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcf79a1bf610b10f42aea489289c5a2c478a786509693b80cd39c44ccd936366"
-
-[[package]]
-name = "futures-util"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c1d6de3acfef38d2be4b1f543f553131788603495be83da675e180c8d6b7bd1"
+checksum = "ccecee823288125bd88b4d7f565c9e58e41858e47ab72e8ea2d64e93624386e0"
 dependencies = [
  "futures-core",
  "futures-task",
- "pin-project-lite",
- "pin-utils",
+ "futures-util",
 ]
 
 [[package]]
-name = "h2"
-version = "0.3.16"
+name = "futures-io"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5be7b54589b581f624f566bf5d8eb2bab1db736c51528720b6bd36b96b55924d"
+checksum = "4fff74096e71ed47f8e023204cfd0aa1289cd54ae5430a9523be060cdb849964"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f43be4fe21a13b9781a69afa4985b0f6ee0e1afab2c6f454a8cf30e2b2237b6e"
+
+[[package]]
+name = "futures-task"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76d3d132be6c0e6aa1534069c705a74a5997a356c0dc2f86a47765e5617c5b65"
+
+[[package]]
+name = "futures-util"
+version = "0.3.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26b01e40b772d54cf6c6d721c1d1abd0647a0106a12ecaa1c186273392a69533"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gimli"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c80984affa11d98d1b88b66ac8853f143217b399d3c74116778ff8fdb4ed2e"
+
+[[package]]
+name = "h2"
+version = "0.3.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ec8491ebaf99c8eaa73058b045fe58073cd6be7f596ac993ced0b0a0c01049"
 dependencies = [
  "bytes",
  "fnv",
@@ -453,12 +605,9 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hermit-abi"
-version = "0.2.6"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
-dependencies = [
- "libc",
-]
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "http"
@@ -502,9 +651,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.24"
+version = "0.14.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e011372fa0b68db8350aa7a248930ecc7839bf46d8485577d69f117a75f164c"
+checksum = "ffb1cfd654a8219eaef89881fdb3bb3b1cdc5fa75ded05d6933b2b382e395468"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -539,33 +688,32 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.53"
+version = "0.1.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64c122667b287044802d6ce17ee2ddf13207ed924c712de9a66a5814d5b64765"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
  "wasm-bindgen",
- "winapi",
+ "windows",
 ]
 
 [[package]]
 name = "iana-time-zone-haiku"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0703ae284fc167426161c2e3f1da3ea71d94b21bedbcc9494e92b28e334e3dca"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
 dependencies = [
- "cxx",
- "cxx-build",
+ "cc",
 ]
 
 [[package]]
 name = "idna"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ddfc70884202db2244c223200c204c2bda1bc6e0998d11b5e024d657209e6"
+checksum = "7d20d6b07bfbc108882d88ed8e37d39636dcc260e15e30c45e6ba089610b917c"
 dependencies = [
  "unicode-bidi",
  "unicode-normalization",
@@ -587,9 +735,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.9.2"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1885e79c1fc4b10f0e172c475f458b7f7b93061064d98c3293e98c5ba0c8b399"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown",
@@ -606,43 +754,43 @@ dependencies = [
 
 [[package]]
 name = "io-lifetimes"
-version = "1.0.3"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46112a93252b123d31a119a8d1a1ac19deac4fac6e0e8b0df58f0d4e5870e63c"
+checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
+ "hermit-abi",
  "libc",
  "windows-sys",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.7.1"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30e22bd8629359895450b59ea7a776c850561b96a3b1d31321c1949d9e6c9146"
+checksum = "28b29a3cd74f0f4598934efe3aeba42bae0eb4680554128851ebbecb02af14e6"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.2"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
- "io-lifetimes",
- "rustix",
+ "rustix 0.38.4",
  "windows-sys",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.5"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fad582f4b9e86b6caa621cabeb0963332d92eea04729ab12892c2533951e6440"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "js-sys"
-version = "0.3.60"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49409df3e3bf0856b916e2ceaca09ee28e6871cf7d9ce97a692cacfdb2a25a47"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -655,18 +803,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
-
-[[package]]
-name = "link-cplusplus"
-version = "1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd207c9c713c34f95a097a5b029ac2ce6010530c7b49d7fea24d977dede04f5"
-dependencies = [
- "cc",
-]
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "linked-hash-map"
@@ -676,15 +815,21 @@ checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.1.4"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f051f77a7c8e6957c0696eac88f26b0117e54f52d3fc682ab19397a8812846a4"
+checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09fc20d2ca12cb9f044c93e3bd6d32d523e6e2ec3db4f7b2939cd99026ecd3f0"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -692,12 +837,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "memchr"
@@ -713,9 +855,9 @@ checksum = "bc4010833aea396656c2f91ee704d51a6f1329ec2ab56ffd00bfd56f7481ea94"
 
 [[package]]
 name = "mime"
-version = "0.3.16"
+version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -735,14 +877,22 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "0.8.5"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
+checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
- "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
+]
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -765,9 +915,9 @@ dependencies = [
 
 [[package]]
 name = "nom"
-version = "7.1.1"
+version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8903e5a29a317527874d0402f867152a3d21c908bb0b933e416c65e301d4c36"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
@@ -805,27 +955,36 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
  "hermit-abi",
  "libc",
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.17.0"
+name = "object"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
+checksum = "8bda667d9f2b5051b8833f59f3bf748b28ef54f850f4fcb389a252aa383866d1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "openssl"
-version = "0.10.45"
+version = "0.10.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
+checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -836,9 +995,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-macros"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -853,32 +1012,25 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.24.0+1.1.1s"
+version = "111.26.0+1.1.1u"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3498f259dab01178c6228c6b00dcef0ed2a2d5e20d648c017861227773ea4abd"
+checksum = "efc62c9f12b22b8f5208c23a7200a442b2e5999f8bdf80233852122b5a4f6f37"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.80"
+version = "0.9.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
 dependencies = [
- "autocfg",
  "cc",
  "libc",
  "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
-
-[[package]]
-name = "os_str_bytes"
-version = "6.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b7820b9daea5457c9f21c69448905d723fbd21136ccf521748f23fd49e723ee"
 
 [[package]]
 name = "parking_lot"
@@ -892,15 +1044,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.6"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba1ef8814b5c993410bb3adfad7a5ed269563e4a2f90c41f5d85be7fb47133bf"
+checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-sys",
+ "windows-targets",
 ]
 
 [[package]]
@@ -911,15 +1063,35 @@ checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
 
 [[package]]
 name = "percent-encoding"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "478c572c3d73181ff3c2539045f6eb99e5491218eae919370993b890cdbdd98e"
+checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
+
+[[package]]
+name = "pin-project"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "030ad2bc4db10a8944cb0d837f158bdfec4d4a4873ab701a95046770d11f8842"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec2e072ecce94ec471b13398d5402c188e76ac03cf74dd1a975161b23a3f6d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
+checksum = "4c40d25201921e5ff0c862a505c6557ea88568a4e3ace775ab55e93f2f4f9d57"
 
 [[package]]
 name = "pin-utils"
@@ -929,9 +1101,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.26"
+version = "0.3.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ac9a59f73473f1b8d852421e59e64809f025994837ef743615c6d0c5b305160"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "png"
@@ -939,7 +1111,7 @@ version = "0.17.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59871cc5b6cce7eaccca5a802b4173377a1c2ba90654246789a8fa2334426d11"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -948,36 +1120,48 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.49"
+version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a8eca9f9c4ffde41714334dee777596264c7825420f521abc92b5b5deb63a5"
+checksum = "92de25114670a878b1261c79c9f8f729fb97e95bac93f6312f583c60dd6a1dfe"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.23"
+version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
+checksum = "5907a1b7c277254a8b15170f6e7c97cfa60ee7872a3217663bb81151e48184bb"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.16"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
 name = "regex"
-version = "1.7.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
+checksum = "b2eae68fc220f7cf2532e4494aded17545fce192d59cd996e0fe7887f4ceb575"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39354c10dd07468c2e73926b23bb9c2caca74c5501e38a35da70406f1d923310"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -986,15 +1170,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.6.28"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
+checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
 
 [[package]]
 name = "reqwest"
-version = "0.11.14"
+version = "0.11.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21eed90ec8570952d53b772ecf8f206aa1ec9a3d76b2521c56c42973f2d91ee9"
+checksum = "cde824a14b7c14f85caff81225f411faacc04a2013f41670f41443742b1c1c55"
 dependencies = [
  "base64",
  "bytes",
@@ -1028,6 +1212,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin 0.5.2",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "rppal"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1037,30 +1236,120 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustix"
-version = "0.36.6"
+name = "rumqttc"
+version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
+checksum = "f2433b134712bc17a6f85a35e06b901e6e8d0bb20b5367e1121e6fedc140c0ac"
 dependencies = [
- "bitflags",
+ "bytes",
+ "flume",
+ "futures",
+ "log",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-webpki 0.100.1",
+ "thiserror",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustix"
+version = "0.37.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d69718bf81c6127a49dc64e44a742e8bb9213c0ff8869a22c308f84c1d4ab06"
+dependencies = [
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.3.8",
  "windows-sys",
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.12"
+name = "rustix"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4b9743ed687d4b4bcedf9ff5eaa7398495ae14e61cba0a295704edbc7decde"
+checksum = "0a962918ea88d644592894bc6dc55acc6c0956488adcebbfb6e273506b7fd6e5"
+dependencies = [
+ "bitflags 2.3.3",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.3",
+ "windows-sys",
+]
+
+[[package]]
+name = "rustls"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79ea77c539259495ce8ca47f53e66ae0330a8819f67e23ac96ca02f50e7b7d36"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki 0.101.1",
+ "sct",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9aace74cb666635c918e9c12bc0d348266037aa8eb599b5cba565709a8dff00"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
+dependencies = [
+ "base64",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.100.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6207cd5ed3d8dca7816f8f3725513a34609c0c765bf652b8c3cb4cfd87db46b"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f36a6828982f422756984e47912a7a51dcbc2a197aa791158f8ca61cd8204e"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "ryu"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "schannel"
-version = "0.1.21"
+version = "0.1.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "713cfb06c7059f3588fb8044c0fad1d09e3c01d225e25b9220dbfdcf16dbb1b3"
+checksum = "0c3733bf4cf7ea0880754e19cb5a462007c4a8c1914bff372ccc95b464f1df88"
 dependencies = [
  "windows-sys",
 ]
@@ -1072,18 +1361,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "scratch"
-version = "1.0.3"
+name = "sct"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddccb15bcce173023b3fedd9436f882a0739b8dfb45e4f6b6002bee5929f61b2"
+checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
+dependencies = [
+ "ring",
+ "untrusted",
+]
 
 [[package]]
 name = "security-framework"
-version = "2.8.2"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a332be01508d814fed64bf28f798a146d73792121129962fdf335bb3c49a4254"
+checksum = "1fc758eb7bffce5b308734e9b0c1468893cae9ff70ebf13e7090be8dcbcc83a8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1092,9 +1385,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.8.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c9bb296072e961fcbd8853511dd39c2d8be2deb1e17c6860b1d30732b323b4"
+checksum = "f51d0c0d83bec45f16480d0ce0058397a69e48fcdc52d1dc8855fb68acbd31a7"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1102,18 +1395,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.152"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb7d1f0d3021d347a83e556fc4683dea2ea09d87bccdf88ff5c12545d89d5efb"
+checksum = "30e27d1e4fd7659406c492fd6cfaf2066ba8773de45ca75e855590f856dc34a9"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.152"
+version = "1.0.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af487d118eecd09402d70a5d72551860e788df87b464af30e5ea6a38c75c541e"
+checksum = "389894603bd18c46fa56231694f8d827779c0951a667087194cf9de94ed24682"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1122,9 +1415,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.91"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877c235533714907a8c2464236f5c4b2a17262ef1bd71f38f35ea592c8da6883"
+checksum = "d03b412469450d4404fe8499a268edd7f8b79fecb074b0d812ad64ca21f4031b"
 dependencies = [
  "itoa",
  "ryu",
@@ -1145,9 +1438,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
 dependencies = [
  "libc",
 ]
@@ -1169,18 +1462,33 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
+checksum = "62bb4feee49fdd9f707ef802e22365a35de4b7b299de4763d44bfea899442ff9"
 
 [[package]]
 name = "socket2"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e2d2db9033d13a1567121ddd7a095ee144db4e1ca1b1bda3419bc0da294ebd"
+checksum = "64a4a911eed85daf18834cfaa86a79b7d266ff93ff5ba14005426219480ed662"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -1191,9 +1499,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.107"
+version = "2.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
+checksum = "45c3457aacde3c65315de5031ec191ce46604304d2446e803d71ade03308d970"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1202,24 +1510,45 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.4.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af18f7ae1acd354b992402e9ec5864359d693cd8a79dcbef59f76891701c1e95"
+checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
 dependencies = [
+ "autocfg",
  "cfg-if",
  "fastrand",
  "redox_syscall",
- "rustix",
+ "rustix 0.37.23",
  "windows-sys",
 ]
 
 [[package]]
 name = "termcolor"
-version = "1.1.3"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a35fc5b8971143ca348fa6df4f024d4d55264f3468c71ad1c2f365b0a4d58c42"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "463fe12d7993d3b327787537ce8dd4dfa058de32fc2b195ef3cde03dc4771e8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1250,14 +1579,14 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.25.0"
+version = "1.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8e00990ebabbe4c14c08aca901caed183ecd5c09562a12c824bb53d3c3fd3af"
+checksum = "532826ff75199d5833b9d2c5fe410f29235e25704ee5f0ef599fb51c21f4a4da"
 dependencies = [
  "autocfg",
+ "backtrace",
  "bytes",
  "libc",
- "memchr",
  "mio",
  "num_cpus",
  "parking_lot",
@@ -1270,9 +1599,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.2"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
+checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1290,10 +1619,31 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-util"
-version = "0.7.7"
+name = "tokio-rustls"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5427d89453009325de0d8f342c9490009f76e999cb7672d77e46267448f7e6b2"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "397c988d37662c7dda6d2208364a706264bf3d6138b11d436cbac0ad38832842"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806fe8c2c87eccc8b3267cbae29ed3ab2d0bd37fca70ab622e46aaa9375ddb7d"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1322,9 +1672,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.30"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24eb03ba0eab1fd845050058ce5e616558e8f8d8fca633e6b163fe25c797213a"
+checksum = "0955b8137a1df6f1a2e9a37d8a6656291ff0297c1a97c24e0d8425fe2312f79a"
 dependencies = [
  "once_cell",
 ]
@@ -1337,15 +1687,15 @@ checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.10"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54675592c1dbefd78cbd98db9bacd89886e1ca50692a0692baefffdeb92dd58"
+checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.6"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84a22b9f218b40614adcb3f4ff08b703773ad44fa9423e4e0d346d5db86e4ebc"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-normalization"
@@ -1357,21 +1707,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-width"
-version = "0.1.10"
+name = "untrusted"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "url"
-version = "2.3.1"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d68c799ae75762b8c3fe375feb6600ef5602c883c5d21eb51c09f22b83c4643"
+checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "vcpkg"
@@ -1381,11 +1737,10 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "want"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
 dependencies = [
- "log",
  "try-lock",
 ]
 
@@ -1403,9 +1758,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.83"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eaf9f5aceeec8be17c128b2e93e031fb8a4d469bb9c4ae2d7dc1888b26887268"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1413,9 +1768,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.83"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c8ffb332579b0557b52d268b91feab8df3615f265d5270fec2a8c95b17c1142"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
@@ -1428,9 +1783,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.33"
+version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23639446165ca5a5de86ae1d8896b737ae80319560fbaa4c2887b7da6e7ebd7d"
+checksum = "c02dbc21516f9f1f04f187958890d7e6026df8d16540b7ad9492bc34a67cea03"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -1440,9 +1795,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.83"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "052be0f94026e6cbc75cdefc9bae13fd6052cdcaf532fa6c45e7ae33a1e6c810"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1450,9 +1805,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.83"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bc0c051dc5f23e307b13285f9d75df86bfdf816c5721e573dec1f9b8aa193c"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1463,15 +1818,15 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.83"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "web-sys"
-version = "0.3.60"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcda906d8be16e728fd5adc5b729afad4e444e106ab28cd1c7256e54fa61510f"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1509,10 +1864,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows-sys"
-version = "0.42.0"
+name = "windows"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
+checksum = "e686886bc078bc1b0b600cac0147aadb815089b6e4da64016cbd754b6342700f"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -1525,45 +1898,45 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 log = "0.4.17"
 env_logger = "0.10.0"
-chrono = "0.4.23"
+chrono = { version = "0.4.23", features = ["serde"] }
 tokio = { version = "1.25", features = ["full"] }
 
 clap = { version = "4.1.1", features = ["cargo"] }
@@ -15,6 +15,7 @@ config = { version = "0.13.3", features = ["yaml"], default-features = false }
 openssl = { version = "0.10", features = ["vendored"] }
 serde = { version = "1.0", features = ["derive"] }
 reqwest = { version = "0.11", features = ["json"] }
+rumqttc = "0.22.0"
 serde_json = "1.0"
 lazy_static = "1.4.0"
 
@@ -23,6 +24,10 @@ rppal = "0.14.1"
 
 [dev-dependencies]
 image = { version = "0.24.6", default-features = false, features = ["png"] }
+tokio-stream = "0.1.14"
+async-stream = "0.3.5"
+futures = "0.3.28"
+regex = "1.9.1"
 
 [package.metadata.cross.build]
 default-target = "arm-unknown-linux-gnueabi"

--- a/src/actor/datalogger.rs
+++ b/src/actor/datalogger.rs
@@ -8,6 +8,8 @@ use DataLoggerMessage::*;
 use crate::actor::linky::{LinkyActorHandle, LinkyMessage};
 use crate::actor::rpict::{RpictActorHandle, RpictMessage};
 
+use crate::service::hassmqtt::HassMqttClient;
+
 use crate::service::influxdb::InfluxDBClient;
 use crate::settings;
 
@@ -15,10 +17,13 @@ use crate::settings;
 pub enum DataLoggerMessage {
     InfluxDbConnected,
     InfluxDbDisconnected,
+    HassMqttConnected,
+    HassMqttDisconnected,
 }
 
 pub struct DataLoggerActor {
     influxdb: Option<InfluxDBClient>,
+    hassmqtt: Option<HassMqttClient>,
     rpict_rx: broadcast::Receiver<RpictMessage>,
     linky_rx: broadcast::Receiver<LinkyMessage>,
     tx: broadcast::Sender<DataLoggerMessage>,
@@ -32,6 +37,7 @@ pub struct DataLoggerHandle {
 impl DataLoggerActor {
     async fn run(&mut self) {
         let mut influxdb_connected = false;
+        let mut hassmqtt_connected = false;
         loop {
             tokio::select! {
                 msg = self.rpict_rx.recv() => match msg {
@@ -46,6 +52,17 @@ impl DataLoggerActor {
                             } else if influxdb_connected {
                                 self.tx.send(InfluxDbDisconnected).unwrap_or_default();
                                 influxdb_connected = false;
+                            }
+                        }
+                        if let Some(client) = &self.hassmqtt {
+                            if client.publish(&frame).await.is_ok() {
+                                if !hassmqtt_connected {
+                                    self.tx.send(HassMqttConnected).unwrap_or_default();
+                                    hassmqtt_connected = true;
+                                }
+                            } else if hassmqtt_connected {
+                                self.tx.send(HassMqttDisconnected).unwrap_or_default();
+                                hassmqtt_connected = false;
                             }
                         }
                     },
@@ -68,6 +85,17 @@ impl DataLoggerActor {
                                 influxdb_connected = false;
                             }
                         }
+                        if let Some(client) = &self.hassmqtt {
+                            if client.publish(&frame).await.is_ok() {
+                                if !hassmqtt_connected {
+                                    self.tx.send(HassMqttConnected).unwrap_or_default();
+                                    hassmqtt_connected = true;
+                                }
+                            } else if hassmqtt_connected {
+                                self.tx.send(HassMqttDisconnected).unwrap_or_default();
+                                hassmqtt_connected = false;
+                            }
+                        }
                     },
                     Err(RecvError::Lagged(skipped)) => {
                         log::warn!("Lag while logging linky data, skipped {:?} frames", skipped);
@@ -81,18 +109,23 @@ impl DataLoggerActor {
 
     pub fn create(
         influxdb_settings: &Option<settings::InfluxDB>,
+        hassmqtt_settings: &Option<settings::HassMqtt>,
         rpict: &RpictActorHandle,
         linky: &LinkyActorHandle,
     ) -> Result<DataLoggerHandle, Box<dyn Error>> {
         let influxdb = influxdb_settings
             .clone()
             .map(|settings| InfluxDBClient::new(&settings).unwrap());
+        let hassmqtt = hassmqtt_settings
+            .clone()
+            .map(|settings| HassMqttClient::new(&settings, None).unwrap());
         let rpict_rx = rpict.subscribe();
         let linky_rx = linky.subscribe();
         // fork
         let (tx, _) = broadcast::channel(1);
         let mut actor = DataLoggerActor {
             influxdb,
+            hassmqtt,
             rpict_rx,
             linky_rx,
             tx: tx.clone(),

--- a/src/actor/hmi.rs
+++ b/src/actor/hmi.rs
@@ -105,6 +105,16 @@ impl HmiActor {
                 self.startup_page.influxdb_status(false);
                 self.display.display_startup_page(&self.startup_page, false).await;
             }
+            DataLoggerMessage::HassMqttConnected => {
+                log::info!("HassMqtt connected");
+                self.startup_page.hassmqtt_status(true);
+                self.display.display_startup_page(&self.startup_page, false).await;
+            }
+            DataLoggerMessage::HassMqttDisconnected => {
+                log::warn!("HassMqtt disconnected");
+                self.startup_page.hassmqtt_status(false);
+                self.display.display_startup_page(&self.startup_page, false).await;
+            }
         }
     }
 

--- a/src/display/pages.rs
+++ b/src/display/pages.rs
@@ -25,6 +25,7 @@ pub struct StartupPage {
     is_rpict_connected: bool,
     is_linky_connected: bool,
     is_influxdb_connected: bool,
+    is_hassmqtt_connected: bool,
     version: String,
 }
 
@@ -35,6 +36,7 @@ impl StartupPage {
             is_rpict_connected: false,
             is_linky_connected: false,
             is_influxdb_connected: false,
+            is_hassmqtt_connected: false,
             version,
         }
     }
@@ -49,6 +51,10 @@ impl StartupPage {
 
     pub fn influxdb_status(&mut self, is_connected: bool) {
         self.is_influxdb_connected = is_connected;
+    }
+
+    pub fn hassmqtt_status(&mut self, is_connected: bool) {
+        self.is_hassmqtt_connected = is_connected;
     }
 }
 
@@ -264,7 +270,7 @@ mod tests {
         let actual = StartupPage::new("0.0.0");
         // Then
         assert!(
-            matches!(actual, StartupPage { is_rpict_connected: false, is_linky_connected: false, is_influxdb_connected: false, version }
+            matches!(actual, StartupPage { is_rpict_connected: false, is_linky_connected: false, is_influxdb_connected: false, is_hassmqtt_connected: false, version }
             if version == "0.0.0")
         );
     }

--- a/src/driver/linky.rs
+++ b/src/driver/linky.rs
@@ -7,10 +7,11 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use rppal::uart::{Parity, Uart};
+use serde::Serialize;
 
 use crate::driver::error::ParseError;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct LinkyFrame {
     pub adco: String, // electric meter address
     pub ptec: String, // current tariff period

--- a/src/driver/rpict.rs
+++ b/src/driver/rpict.rs
@@ -6,10 +6,11 @@ use std::time::Duration;
 
 use chrono::{DateTime, Utc};
 use rppal::uart::{Parity, Uart};
+use serde::Serialize;
 
 use crate::driver::error::ParseError;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 pub struct RpictFrame {
     pub node_id: u8,
     pub l1_real_power: f32,

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let rpict = RpictActor::create(&settings.serial.rpict);
     let linky = LinkyActor::create(&settings.serial.linky);
-    let datalogger = DataLoggerActor::create(&settings.influxdb, &rpict, &linky)?;
+    let datalogger = DataLoggerActor::create(&settings.influxdb, &settings.hassmqtt, &rpict, &linky)?;
     let hmi = HmiActor::create(&settings.hmi, &rpict, &linky, &datalogger)?;
     log::info!("energy-monitor started");
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -1,1 +1,2 @@
+pub mod hassmqtt;
 pub mod influxdb;

--- a/src/service/hassmqtt.rs
+++ b/src/service/hassmqtt.rs
@@ -1,0 +1,369 @@
+use rumqttc::{AsyncClient, LastWill, MqttOptions, QoS};
+
+use serde_json::json;
+
+use std::error::Error;
+use std::time::Duration;
+
+use crate::driver::linky::LinkyFrame;
+use crate::driver::rpict::RpictFrame;
+use crate::settings;
+
+const DEVICE_NAME: &str = "energy-monitor";
+
+pub struct HassMqttClient {
+    client: AsyncClient,
+    topic_prefix: String,
+    discovery_topic_prefix: String,
+    status_topic: String,
+}
+
+#[derive(Debug)]
+pub enum HassMqttClientError {
+    Publish,
+}
+
+impl HassMqttClient {
+    pub fn new(settings: &settings::HassMqtt, topic_prefix: Option<&String>) -> Result<HassMqttClient, Box<dyn Error>> {
+        let topic_prefix = topic_prefix
+            .filter(|s| !s.is_empty())
+            .map_or(String::from(""), |prefix| prefix.clone() + "/");
+        let discovery_topic_prefix = topic_prefix.clone() + "homeassistant/";
+        let status_topic = topic_prefix.clone() + DEVICE_NAME + "/status";
+
+        let settings = settings.clone();
+        let client_id = topic_prefix.clone() + DEVICE_NAME;
+        let mut mqtt_options = MqttOptions::new(client_id, settings.host, settings.port);
+        if let (Some(username), Some(password)) = (settings.username, settings.password) {
+            mqtt_options.set_credentials(username, password);
+        }
+        mqtt_options.set_keep_alive(Duration::from_secs(60));
+        mqtt_options.set_last_will(LastWill::new(&status_topic, "offline", QoS::AtLeastOnce, false));
+        let (client, mut eventloop) = AsyncClient::new(mqtt_options, 1);
+
+        tokio::task::spawn(async move {
+            loop {
+                match eventloop.poll().await {
+                    Ok(_) => {}
+                    Err(e) => {
+                        log::error!("MQTT error = {e:?}");
+                        return;
+                    }
+                }
+            }
+        });
+
+        Ok(HassMqttClient {
+            client,
+            topic_prefix,
+            discovery_topic_prefix,
+            status_topic,
+        })
+    }
+
+    pub async fn announce(&self) {
+        let mut sensors: Vec<Sensor> = vec![];
+        sensors.extend(RpictFrame::sensors());
+        sensors.extend(LinkyFrame::sensors());
+        for sensor in sensors {
+            let Message { topic, payload } = sensor.to_config_message(&self.status_topic);
+            let topic = self.discovery_topic_prefix.clone() + topic.as_str();
+            self.client
+                .publish(&topic, QoS::AtLeastOnce, false, payload)
+                .await
+                .unwrap();
+        }
+        self.client
+            .publish(&self.status_topic, QoS::AtLeastOnce, false, "online")
+            .await
+            .unwrap();
+    }
+
+    pub async fn publish(&self, payload: &impl Publishable) -> Result<(), HassMqttClientError> {
+        let Message { topic, payload } = payload.to_state_message();
+        let topic = self.topic_prefix.clone() + topic.as_str();
+        self.client
+            .publish(&topic, QoS::AtLeastOnce, false, payload)
+            .await
+            .map_err(|_| HassMqttClientError::Publish)
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Message {
+    pub topic: String,
+    pub payload: String,
+}
+
+#[derive(Debug)]
+pub struct Sensor {
+    pub name: String,
+    pub source: String,
+    pub device_class: String,
+    pub state_class: String,
+    pub unit_of_measurement: String,
+}
+
+impl Sensor {
+    fn to_config_message(&self, status_topic: &str) -> Message {
+        let topic = format!("sensor/energy-monitor/{}/config", self.name);
+        let payload = serde_json::to_string(&json!({
+          "availability_topic": status_topic,
+          "state_topic": format!("energy-monitor/{source}", source = self.source),
+          "value_template": format!("{{{{ value_json.{sensor} }}}}", sensor = self.name),
+          "device": {
+            "name": DEVICE_NAME,
+            "manufacturer": "DIY",
+            "sw_version": env!("CARGO_PKG_VERSION")
+          },
+          "unique_id": format!("energy-monitor_{}_{}", self.source, self.name),
+          "name": format!("energy-monitor {} {}", self.source, self.name),
+          "device_class": self.device_class,
+          "state_class": self.state_class,
+          "unit_of_measurement": self.unit_of_measurement,
+          "enabled_by_default": true,
+          "entity_category": "diagnostic",
+          "icon": "mdi:lightning-bolt"
+        }))
+        .unwrap();
+        Message { topic, payload }
+    }
+}
+
+pub trait Publishable {
+    fn to_state_message(&self) -> Message;
+}
+
+impl RpictFrame {
+    pub fn sensors() -> Vec<Sensor> {
+        // See documentation: http://lechacal.com/wiki/index.php/RPICT3V1
+        vec![
+            Sensor {
+                name: "l1_real_power".to_string(),
+                source: "rpict".to_string(),
+                device_class: "power".to_string(),
+                state_class: "measurement".to_string(),
+                unit_of_measurement: "W".to_string(),
+            },
+            Sensor {
+                name: "l1_apparent_power".to_string(),
+                source: "rpict".to_string(),
+                device_class: "apparent_power".to_string(),
+                state_class: "measurement".to_string(),
+                unit_of_measurement: "VA".to_string(),
+            },
+            Sensor {
+                name: "l1_irms".to_string(),
+                source: "rpict".to_string(),
+                device_class: "current".to_string(),
+                state_class: "measurement".to_string(),
+                unit_of_measurement: "A".to_string(),
+            },
+            Sensor {
+                name: "l1_vrms".to_string(),
+                source: "rpict".to_string(),
+                device_class: "voltage".to_string(),
+                state_class: "measurement".to_string(),
+                unit_of_measurement: "V".to_string(),
+            },
+            Sensor {
+                name: "l1_power_factor".to_string(),
+                source: "rpict".to_string(),
+                device_class: "power_factor".to_string(),
+                state_class: "measurement".to_string(),
+                unit_of_measurement: "%".to_string(),
+            },
+            Sensor {
+                name: "l2_real_power".to_string(),
+                source: "rpict".to_string(),
+                device_class: "power".to_string(),
+                state_class: "measurement".to_string(),
+                unit_of_measurement: "W".to_string(),
+            },
+            Sensor {
+                name: "l2_apparent_power".to_string(),
+                source: "rpict".to_string(),
+                device_class: "apparent_power".to_string(),
+                state_class: "measurement".to_string(),
+                unit_of_measurement: "VA".to_string(),
+            },
+            Sensor {
+                name: "l2_irms".to_string(),
+                source: "rpict".to_string(),
+                device_class: "current".to_string(),
+                state_class: "measurement".to_string(),
+                unit_of_measurement: "A".to_string(),
+            },
+            Sensor {
+                name: "l2_vrms".to_string(),
+                source: "rpict".to_string(),
+                device_class: "voltage".to_string(),
+                state_class: "measurement".to_string(),
+                unit_of_measurement: "V".to_string(),
+            },
+            Sensor {
+                name: "l2_power_factor".to_string(),
+                source: "rpict".to_string(),
+                device_class: "power_factor".to_string(),
+                state_class: "measurement".to_string(),
+                unit_of_measurement: "%".to_string(),
+            },
+            Sensor {
+                name: "l3_real_power".to_string(),
+                source: "rpict".to_string(),
+                device_class: "power".to_string(),
+                state_class: "measurement".to_string(),
+                unit_of_measurement: "W".to_string(),
+            },
+            Sensor {
+                name: "l3_apparent_power".to_string(),
+                source: "rpict".to_string(),
+                device_class: "apparent_power".to_string(),
+                state_class: "measurement".to_string(),
+                unit_of_measurement: "VA".to_string(),
+            },
+            Sensor {
+                name: "l3_irms".to_string(),
+                source: "rpict".to_string(),
+                device_class: "current".to_string(),
+                state_class: "measurement".to_string(),
+                unit_of_measurement: "A".to_string(),
+            },
+            Sensor {
+                name: "l3_vrms".to_string(),
+                source: "rpict".to_string(),
+                device_class: "voltage".to_string(),
+                state_class: "measurement".to_string(),
+                unit_of_measurement: "V".to_string(),
+            },
+            Sensor {
+                name: "l3_power_factor".to_string(),
+                source: "rpict".to_string(),
+                device_class: "power_factor".to_string(),
+                state_class: "measurement".to_string(),
+                unit_of_measurement: "%".to_string(),
+            },
+        ]
+    }
+}
+
+impl Publishable for RpictFrame {
+    fn to_state_message(&self) -> Message {
+        let topic = String::from("energy-monitor/rpict");
+        let payload = serde_json::to_string(self).unwrap();
+        Message { topic, payload }
+    }
+}
+
+impl LinkyFrame {
+    pub fn sensors() -> Vec<Sensor> {
+        vec![
+            Sensor {
+                name: "hchp".to_string(),
+                source: "linky".to_string(),
+                device_class: "energy".to_string(),
+                state_class: "total".to_string(),
+                unit_of_measurement: "Wh".to_string(),
+            },
+            Sensor {
+                name: "hchc".to_string(),
+                source: "linky".to_string(),
+                device_class: "energy".to_string(),
+                state_class: "total".to_string(),
+                unit_of_measurement: "Wh".to_string(),
+            },
+        ]
+    }
+}
+
+impl Publishable for LinkyFrame {
+    fn to_state_message(&self) -> Message {
+        let topic = String::from("energy-monitor/linky");
+        let payload = serde_json::to_string(self).unwrap();
+        Message { topic, payload }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{DateTime, Utc};
+
+    lazy_static! {
+        pub static ref TIMESTAMP: DateTime<Utc> = DateTime::parse_from_rfc3339("2023-07-09T14:01:10Z")
+            .unwrap()
+            .with_timezone(&Utc);
+    }
+
+    #[test]
+    fn test_sensorconfig_to_discovery_message() {
+        // Given
+        let now = Sensor {
+            name: "sensor".to_string(),
+            source: "source".to_string(),
+            device_class: "device_class".to_string(),
+            state_class: "state_class".to_string(),
+            unit_of_measurement: "unit_of_measurement".to_string(),
+        };
+        // When
+        let Message { topic, payload } = now.to_config_message("status");
+        // Then
+        assert_eq!(topic, "sensor/energy-monitor/sensor/config");
+        assert_eq!(
+            payload,
+            r#"{"availability_topic":"status","device":{"manufacturer":"DIY","name":"energy-monitor","sw_version":"0.1.0"},"device_class":"device_class","enabled_by_default":true,"entity_category":"diagnostic","icon":"mdi:lightning-bolt","name":"energy-monitor source sensor","state_class":"state_class","state_topic":"energy-monitor/source","unique_id":"energy-monitor_source_sensor","unit_of_measurement":"unit_of_measurement","value_template":"{{ value_json.sensor }}"}"#
+        );
+    }
+
+    #[test]
+    fn test_linkyframe_to_message() {
+        // Given
+        let frame = LinkyFrame {
+            adco: "041876097767".to_string(),
+            ptec: "HP".to_string(),
+            hchc: 19_650_909,
+            hchp: 43_280_553,
+            timestamp: *TIMESTAMP,
+        };
+        // When
+        let Message { topic, payload } = frame.to_state_message();
+        // Then
+        assert_eq!(topic, "energy-monitor/linky");
+        assert_eq!(
+            payload,
+            r#"{"adco":"041876097767","ptec":"HP","hchc":19650909,"hchp":43280553,"timestamp":"2023-07-09T14:01:10Z"}"#
+        );
+    }
+
+    #[test]
+    fn test_rpictframe_to_message() {
+        // Given
+        let frame = RpictFrame {
+            node_id: 11,
+            l1_real_power: -82.96,
+            l1_apparent_power: 422.95,
+            l1_irms: 1.64,
+            l1_vrms: 257.65,
+            l1_power_factor: 0.194,
+            l2_real_power: -50.23,
+            l2_apparent_power: 144.52,
+            l2_irms: 0.56,
+            l2_vrms: 259.95,
+            l2_power_factor: 0.346,
+            l3_real_power: 24.55,
+            l3_apparent_power: 47.17,
+            l3_irms: 0.18,
+            l3_vrms: 259.7,
+            l3_power_factor: 0.509,
+            timestamp: *TIMESTAMP,
+        };
+        // When
+        let Message { topic, payload } = frame.to_state_message();
+        // Then
+        assert_eq!(topic, "energy-monitor/rpict");
+        assert_eq!(
+            payload,
+            r#"{"node_id":11,"l1_real_power":-82.96,"l1_apparent_power":422.95,"l1_irms":1.64,"l1_vrms":257.65,"l1_power_factor":0.194,"l2_real_power":-50.23,"l2_apparent_power":144.52,"l2_irms":0.56,"l2_vrms":259.95,"l2_power_factor":0.346,"l3_real_power":24.55,"l3_apparent_power":47.17,"l3_irms":0.18,"l3_vrms":259.7,"l3_power_factor":0.509,"timestamp":"2023-07-09T14:01:10Z"}"#
+        );
+    }
+}

--- a/src/settings.default.yml
+++ b/src/settings.default.yml
@@ -7,8 +7,5 @@ hmi:
 serial:
   rpict: /dev/ttyAMA0
   linky: /dev/ttyUSB0
-influxdb:
-  host: localhost
-  port: 8086
-  database: metrology
-  prefix: energy
+influxdb: null
+hassmqtt: null

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -36,11 +36,21 @@ impl InfluxDB {
 
 #[derive(Debug, Deserialize, Clone)]
 #[allow(unused)]
+pub struct HassMqtt {
+    pub host: String,
+    pub port: u16,
+    pub username: Option<String>,
+    pub password: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+#[allow(unused)]
 pub struct Settings {
     pub log_level: String,
     pub hmi: Hmi,
     pub serial: Serial,
     pub influxdb: Option<InfluxDB>,
+    pub hassmqtt: Option<HassMqtt>,
 }
 
 impl Settings {

--- a/tests/hassmqtt_test.rs
+++ b/tests/hassmqtt_test.rs
@@ -1,0 +1,207 @@
+use std::error::Error;
+
+use std::time::Duration;
+
+use async_stream::stream;
+use chrono::{DateTime, Utc};
+
+use regex::Regex;
+
+use log::{error, LevelFilter};
+use rumqttc::{AsyncClient, Event, Incoming, MqttOptions, QoS};
+
+use serde_json::Value;
+
+use energy_monitor::driver::linky::LinkyFrame;
+use energy_monitor::driver::rpict::RpictFrame;
+use energy_monitor::service::hassmqtt::{HassMqttClient, Message, Sensor};
+use energy_monitor::settings::HassMqtt;
+
+use futures::stream::BoxStream;
+use lazy_static::lazy_static;
+use tokio::sync::mpsc;
+use tokio_stream::StreamExt;
+
+struct TestContext<'a> {
+    test_id: String,
+    messages: BoxStream<'a, Message>,
+    settings: HassMqtt,
+}
+
+impl TestContext<'_> {
+    async fn new<'a>() -> Result<TestContext<'a>, Box<dyn Error>> {
+        let _ = env_logger::builder()
+            .is_test(true)
+            .filter_level(LevelFilter::Info)
+            .try_init();
+        let test_id = Utc::now().timestamp_micros().to_string();
+        // Create listener client
+        const MQTT_HOST: &str = "test.mosquitto.org";
+        const MQTT_PORT: u16 = 1883;
+        let mut mqtt_options = MqttOptions::new(test_id.clone() + "/test-listener", MQTT_HOST, MQTT_PORT);
+        mqtt_options.set_keep_alive(Duration::from_secs(60));
+        let (client, mut eventloop) = AsyncClient::new(mqtt_options, 100);
+        client.subscribe(test_id.clone() + "/#", QoS::AtLeastOnce).await?;
+        let _ = eventloop.poll().await; // warmup connection
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        tokio::task::spawn(async move {
+            loop {
+                match eventloop.poll().await {
+                    Ok(Event::Incoming(Incoming::Publish(p))) => tx.send(p).unwrap(),
+                    Err(e) => error!("MQTT error: {e:?}"),
+                    _ => (),
+                }
+            }
+        });
+        let stream = stream! {
+            while let Some(p) = rx.recv().await {
+                yield Message {
+                    topic: p.topic ,
+                    payload: String::from_utf8(p.payload.to_vec()).unwrap()
+                };
+            }
+        };
+
+        Ok(TestContext {
+            test_id,
+            messages: Box::pin(stream),
+            settings: HassMqtt {
+                host: MQTT_HOST.to_string(),
+                port: MQTT_PORT,
+                username: None,
+                password: None,
+            },
+        })
+    }
+}
+
+lazy_static! {
+    pub static ref TIMESTAMP: DateTime<Utc> = DateTime::parse_from_rfc3339("2023-07-09T14:01:10Z")
+        .unwrap()
+        .with_timezone(&Utc);
+}
+
+#[tokio::test]
+async fn test_hassmqttclient_announce_sensors() {
+    // Given
+    let context = TestContext::new().await.unwrap();
+    let client = HassMqttClient::new(&context.settings, Some(&context.test_id)).unwrap();
+    let topic_regex = Regex::new(r"^\d+/homeassistant/sensor/energy-monitor/(?<sensor>[^/]+)/config$").unwrap();
+    let mut sensors: Vec<Sensor> = RpictFrame::sensors()
+        .into_iter()
+        .chain(LinkyFrame::sensors().into_iter())
+        .collect();
+    let mut seen: Vec<Sensor> = vec![];
+    // When
+    client.announce().await;
+    // Then
+    let stream = context.messages.take_while(|m| m.topic.ends_with("/config"));
+    tokio::pin!(stream);
+
+    while let Some(Message { topic, payload }) = stream.next().await {
+        assert!(topic_regex.is_match(&topic), "unexpected topic {}", topic);
+        let sensor_name = topic_regex
+            .captures(&topic)
+            .and_then(|x| x.name("sensor"))
+            .map(|x| x.as_str())
+            .unwrap();
+        let sensor = sensors
+            .iter()
+            .position(|s| s.name == sensor_name)
+            .map(|i| seen.push(sensors.swap_remove(i)));
+        assert!(sensor.is_some(), "unexpected sensor {}", sensor_name);
+        let payload: Value = serde_json::from_str(&payload).unwrap();
+        assert_eq!(
+            format!("{}/energy-monitor/status", &context.test_id),
+            payload["availability_topic"],
+            "unexpected availability_topic"
+        );
+    }
+
+    assert!(sensors.is_empty(), "sensor(s) was not announced: {:?}", sensors);
+}
+
+#[tokio::test]
+async fn test_hassmqttclient_announce_online() {
+    // Given
+    let context = TestContext::new().await.unwrap();
+    let client = HassMqttClient::new(&context.settings, Some(&context.test_id)).unwrap();
+    // When
+    client.announce().await;
+    // Then
+    let stream = context.messages.skip_while(|m| m.topic.ends_with("/config"));
+    tokio::pin!(stream);
+    let topic = format!("{}/energy-monitor/status", &context.test_id);
+    let payload = "online".to_string();
+    assert_eq!(
+        Some(Message { topic, payload }),
+        stream.next().await,
+        "unexpected message"
+    );
+}
+
+#[tokio::test]
+async fn test_hassmqttclient_publish_rpictframe() {
+    // Given
+    let context = TestContext::new().await.unwrap();
+    let client = HassMqttClient::new(&context.settings, Some(&context.test_id)).unwrap();
+    let frame = RpictFrame {
+        node_id: 11,
+        l1_real_power: -82.96,
+        l1_apparent_power: 422.95,
+        l1_irms: 1.64,
+        l1_vrms: 257.65,
+        l1_power_factor: 0.194,
+        l2_real_power: -50.23,
+        l2_apparent_power: 144.52,
+        l2_irms: 0.56,
+        l2_vrms: 259.95,
+        l2_power_factor: 0.346,
+        l3_real_power: 24.55,
+        l3_apparent_power: 47.17,
+        l3_irms: 0.18,
+        l3_vrms: 259.7,
+        l3_power_factor: 0.509,
+        timestamp: *TIMESTAMP,
+    };
+    // When
+    client.publish(&frame).await.unwrap();
+    // Then
+    let stream = context.messages;
+    tokio::pin!(stream);
+    let topic = format!("{}/energy-monitor/rpict", &context.test_id);
+    let payload = r#"{"node_id":11,"l1_real_power":-82.96,"l1_apparent_power":422.95,"l1_irms":1.64,"l1_vrms":257.65,"l1_power_factor":0.194,"l2_real_power":-50.23,"l2_apparent_power":144.52,"l2_irms":0.56,"l2_vrms":259.95,"l2_power_factor":0.346,"l3_real_power":24.55,"l3_apparent_power":47.17,"l3_irms":0.18,"l3_vrms":259.7,"l3_power_factor":0.509,"timestamp":"2023-07-09T14:01:10Z"}"#.to_string();
+    assert_eq!(
+        Some(Message { topic, payload }),
+        stream.next().await,
+        "unexpected message"
+    );
+}
+
+#[tokio::test]
+async fn test_hassmqttclient_publish_linkyframe() {
+    // Given
+    let context = TestContext::new().await.unwrap();
+    let client = HassMqttClient::new(&context.settings, Some(&context.test_id)).unwrap();
+    let frame = LinkyFrame {
+        adco: "041876097767".to_string(),
+        ptec: "HP".to_string(),
+        hchc: 19_650_909,
+        hchp: 43_280_553,
+        timestamp: *TIMESTAMP,
+    };
+    // When
+    client.publish(&frame).await.unwrap();
+    // Then
+    let stream = context.messages;
+    tokio::pin!(stream);
+    let topic = format!("{}/energy-monitor/linky", &context.test_id);
+    let payload =
+        r#"{"adco":"041876097767","ptec":"HP","hchc":19650909,"hchp":43280553,"timestamp":"2023-07-09T14:01:10Z"}"#
+            .to_string();
+    assert_eq!(
+        Some(Message { topic, payload }),
+        stream.next().await,
+        "unexpected message"
+    );
+}


### PR DESCRIPTION
Resolves #24

This PR adds Home Assistant MQTT support so that energy-monitor measurements can be stored and used with [electricity grid integration](https://www.home-assistant.io/docs/energy/electricity-grid/).
