### PR TITLE
Reconnect blocking actors and propagate UART errors

### DIFF
--- a/src/actor.rs
+++ b/src/actor.rs
@@ -1,3 +1,4 @@
+pub mod blocking;
 pub mod button;
 pub mod datalogger;
 pub mod display;

--- a/src/actor/blocking.rs
+++ b/src/actor/blocking.rs
@@ -1,0 +1,238 @@
+use std::error::Error;
+use std::time::Duration;
+
+use tokio::sync::broadcast;
+
+pub trait ConnectionMessage: Clone + Send + 'static {
+    type Frame;
+    fn connected() -> Self;
+    fn disconnected() -> Self;
+    fn frame(frame: Self::Frame) -> Self;
+}
+
+pub const INITIAL_BACKOFF: Duration = Duration::from_secs(1);
+pub const MAX_BACKOFF: Duration = Duration::from_secs(60);
+
+pub fn run_blocking_actor<M, A, I, S>(
+    attempts: A,
+    tx: broadcast::Sender<M>,
+    mut sleeper: S,
+) where
+    M: ConnectionMessage,
+    A: IntoIterator<Item = Result<I, Box<dyn Error>>>,
+    I: IntoIterator<Item = M::Frame>,
+    S: FnMut(Duration),
+{
+    let mut backoff = INITIAL_BACKOFF;
+    for attempt in attempts {
+        match attempt {
+            Err(e) => {
+                log::warn!("connect failed: {e:?}; retrying in {backoff:?}");
+                let _ = tx.send(M::disconnected());
+                sleeper(backoff);
+                backoff = (backoff * 2).min(MAX_BACKOFF);
+            }
+            Ok(iter) => {
+                let _ = tx.send(M::connected());
+                let mut produced = false;
+                for frame in iter {
+                    produced = true;
+                    if tx.send(M::frame(frame)).is_err() {
+                        return;
+                    }
+                }
+                let _ = tx.send(M::disconnected());
+                if produced {
+                    log::warn!("iterator ended after producing data; reconnecting");
+                    backoff = INITIAL_BACKOFF;
+                } else {
+                    log::warn!("iterator ended without producing data; retrying in {backoff:?}");
+                    sleeper(backoff);
+                    backoff = (backoff * 2).min(MAX_BACKOFF);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+
+    #[derive(Clone, Debug, PartialEq)]
+    enum TestMsg {
+        Connected,
+        Disconnected,
+        Frame(u32),
+    }
+
+    impl ConnectionMessage for TestMsg {
+        type Frame = u32;
+        fn connected() -> Self {
+            TestMsg::Connected
+        }
+        fn disconnected() -> Self {
+            TestMsg::Disconnected
+        }
+        fn frame(f: u32) -> Self {
+            TestMsg::Frame(f)
+        }
+    }
+
+    fn drain(rx: &mut broadcast::Receiver<TestMsg>) -> Vec<TestMsg> {
+        let mut out = Vec::new();
+        while let Ok(m) = rx.try_recv() {
+            out.push(m);
+        }
+        out
+    }
+
+    fn err(msg: &'static str) -> Box<dyn Error> {
+        msg.into()
+    }
+
+    #[test]
+    fn success_emits_connected_frames_disconnected_no_sleep() {
+        let (tx, mut rx) = broadcast::channel(64);
+        let attempts: Vec<Result<Vec<u32>, Box<dyn Error>>> = vec![Ok(vec![1, 2, 3])];
+        let sleeps = Arc::new(Mutex::new(Vec::<Duration>::new()));
+        let sleeps_c = Arc::clone(&sleeps);
+
+        run_blocking_actor::<TestMsg, _, _, _>(
+            attempts,
+            tx,
+            |d| sleeps_c.lock().unwrap().push(d),
+        );
+
+        assert_eq!(
+            drain(&mut rx),
+            vec![
+                TestMsg::Connected,
+                TestMsg::Frame(1),
+                TestMsg::Frame(2),
+                TestMsg::Frame(3),
+                TestMsg::Disconnected,
+            ]
+        );
+        assert!(
+            sleeps.lock().unwrap().is_empty(),
+            "no sleep expected on healthy success path"
+        );
+    }
+
+    #[test]
+    fn build_failure_emits_disconnected_and_sleeps_initial_backoff() {
+        let (tx, mut rx) = broadcast::channel(64);
+        let attempts: Vec<Result<Vec<u32>, Box<dyn Error>>> = vec![Err(err("boom"))];
+        let sleeps = Arc::new(Mutex::new(Vec::<Duration>::new()));
+        let sleeps_c = Arc::clone(&sleeps);
+
+        run_blocking_actor::<TestMsg, _, _, _>(
+            attempts,
+            tx,
+            |d| sleeps_c.lock().unwrap().push(d),
+        );
+
+        assert_eq!(drain(&mut rx), vec![TestMsg::Disconnected]);
+        assert_eq!(*sleeps.lock().unwrap(), vec![INITIAL_BACKOFF]);
+    }
+
+    #[test]
+    fn consecutive_failures_backoff_exponentially_capped_at_max() {
+        let (tx, _rx) = broadcast::channel(256);
+        let attempts: Vec<Result<Vec<u32>, Box<dyn Error>>> =
+            (0..10).map(|_| Err(err("boom"))).collect();
+        let sleeps = Arc::new(Mutex::new(Vec::<Duration>::new()));
+        let sleeps_c = Arc::clone(&sleeps);
+
+        run_blocking_actor::<TestMsg, _, _, _>(
+            attempts,
+            tx,
+            |d| sleeps_c.lock().unwrap().push(d),
+        );
+
+        let expected = vec![
+            Duration::from_secs(1),
+            Duration::from_secs(2),
+            Duration::from_secs(4),
+            Duration::from_secs(8),
+            Duration::from_secs(16),
+            Duration::from_secs(32),
+            Duration::from_secs(60),
+            Duration::from_secs(60),
+            Duration::from_secs(60),
+            Duration::from_secs(60),
+        ];
+        assert_eq!(*sleeps.lock().unwrap(), expected);
+    }
+
+    #[test]
+    fn successful_frame_resets_backoff() {
+        let (tx, _rx) = broadcast::channel(64);
+        let attempts: Vec<Result<Vec<u32>, Box<dyn Error>>> = vec![
+            Err(err("boom1")),
+            Err(err("boom2")),
+            Ok(vec![42]),
+            Err(err("boom3")),
+        ];
+        let sleeps = Arc::new(Mutex::new(Vec::<Duration>::new()));
+        let sleeps_c = Arc::clone(&sleeps);
+
+        run_blocking_actor::<TestMsg, _, _, _>(
+            attempts,
+            tx,
+            |d| sleeps_c.lock().unwrap().push(d),
+        );
+
+        assert_eq!(
+            *sleeps.lock().unwrap(),
+            vec![
+                Duration::from_secs(1), // after first failure
+                Duration::from_secs(2), // after second failure (exp backoff)
+                Duration::from_secs(1), // after third failure: backoff reset by yielded frame
+            ]
+        );
+    }
+
+    #[test]
+    fn empty_iter_sleeps_with_backoff_to_avoid_busy_loop() {
+        let (tx, _rx) = broadcast::channel(64);
+        let attempts: Vec<Result<Vec<u32>, Box<dyn Error>>> = vec![Ok(vec![]), Ok(vec![])];
+        let sleeps = Arc::new(Mutex::new(Vec::<Duration>::new()));
+        let sleeps_c = Arc::clone(&sleeps);
+
+        run_blocking_actor::<TestMsg, _, _, _>(
+            attempts,
+            tx,
+            |d| sleeps_c.lock().unwrap().push(d),
+        );
+
+        assert_eq!(
+            *sleeps.lock().unwrap(),
+            vec![Duration::from_secs(1), Duration::from_secs(2)]
+        );
+    }
+
+    #[test]
+    fn exits_when_subscribers_dropped_mid_iteration() {
+        let (tx, rx) = broadcast::channel::<TestMsg>(64);
+        drop(rx);
+        let attempts_called = Arc::new(Mutex::new(0u32));
+        let attempts_called_c = Arc::clone(&attempts_called);
+        let attempts: Vec<Result<Vec<u32>, Box<dyn Error>>> =
+            vec![Ok(vec![1, 2, 3]), Ok(vec![4, 5, 6])];
+        let counted = attempts.into_iter().inspect(move |_| {
+            *attempts_called_c.lock().unwrap() += 1;
+        });
+
+        run_blocking_actor::<TestMsg, _, _, _>(counted, tx, |_| panic!("no sleep expected"));
+
+        assert_eq!(
+            *attempts_called.lock().unwrap(),
+            1,
+            "loop must abort after first send-frame failure, not continue to second attempt"
+        );
+    }
+}

--- a/src/actor/linky.rs
+++ b/src/actor/linky.rs
@@ -1,9 +1,9 @@
 use std::thread::sleep;
-use std::time::Duration;
 use tokio::sync::broadcast;
 
 use LinkyMessage::*;
 
+use crate::actor::blocking::{run_blocking_actor, ConnectionMessage};
 use crate::driver::linky::{Linky, LinkyFrame};
 
 #[derive(Clone, Debug)]
@@ -11,6 +11,19 @@ pub enum LinkyMessage {
     Connected,
     Disconnected,
     NewFrame(LinkyFrame),
+}
+
+impl ConnectionMessage for LinkyMessage {
+    type Frame = LinkyFrame;
+    fn connected() -> Self {
+        Connected
+    }
+    fn disconnected() -> Self {
+        Disconnected
+    }
+    fn frame(frame: LinkyFrame) -> Self {
+        NewFrame(frame)
+    }
 }
 
 pub struct LinkyActor;
@@ -26,20 +39,10 @@ impl LinkyActor {
         let (tx, _) = broadcast::channel(5);
         let tx2 = tx.clone();
         tokio::task::spawn_blocking(move || {
-            sleep(Duration::from_secs(1));
-            let iter = Linky::builder().with_port_path(serial_path).build();
-            if let Err(e) = iter {
-                log::debug!("Cannot connect Linky: {:?}", e);
-                tx.send(Disconnected).unwrap_or_default();
-                return;
-            } else {
-                tx.send(Connected).unwrap_or_default();
-            }
-            for frame in iter.unwrap() {
-                if tx.send(NewFrame(frame)).is_err() {
-                    break;
-                }
-            }
+            let attempts = std::iter::repeat_with(move || {
+                Linky::builder().with_port_path(serial_path.clone()).build()
+            });
+            run_blocking_actor::<LinkyMessage, _, _, _>(attempts, tx, sleep);
         });
         LinkyActorHandle { tx: tx2 }
     }

--- a/src/actor/rpict.rs
+++ b/src/actor/rpict.rs
@@ -1,9 +1,9 @@
 use std::thread::sleep;
-use std::time::Duration;
 use tokio::sync::broadcast;
 
 use RpictMessage::*;
 
+use crate::actor::blocking::{run_blocking_actor, ConnectionMessage};
 use crate::driver::rpict::{Rpict, RpictFrame};
 
 #[derive(Clone, Debug)]
@@ -11,6 +11,19 @@ pub enum RpictMessage {
     Connected,
     Disconnected,
     NewFrame(RpictFrame),
+}
+
+impl ConnectionMessage for RpictMessage {
+    type Frame = RpictFrame;
+    fn connected() -> Self {
+        Connected
+    }
+    fn disconnected() -> Self {
+        Disconnected
+    }
+    fn frame(frame: RpictFrame) -> Self {
+        NewFrame(frame)
+    }
 }
 
 pub struct RpictActor;
@@ -26,20 +39,10 @@ impl RpictActor {
         let (tx, _) = broadcast::channel(5);
         let tx2 = tx.clone();
         tokio::task::spawn_blocking(move || {
-            sleep(Duration::from_secs(1));
-            let iter = Rpict::builder().with_port_path(serial_path).build();
-            if let Err(e) = iter {
-                log::debug!("Cannot connect Rpict: {:?}", e);
-                tx.send(Disconnected).unwrap_or_default();
-                return;
-            } else {
-                tx.send(Connected).unwrap_or_default();
-            }
-            for frame in iter.unwrap() {
-                if tx.send(NewFrame(frame)).is_err() {
-                    break;
-                }
-            }
+            let attempts = std::iter::repeat_with(move || {
+                Rpict::builder().with_port_path(serial_path.clone()).build()
+            });
+            run_blocking_actor::<RpictMessage, _, _, _>(attempts, tx, sleep);
         });
         RpictActorHandle { tx: tx2 }
     }

--- a/src/driver/linky.rs
+++ b/src/driver/linky.rs
@@ -122,16 +122,17 @@ impl Linky {
             source_iter,
             dt_gen,
         } = self;
-        let source_iter = source_iter
-            .or_else(|| {
-                let port_path = port_path.expect("no port path provided");
+        let source_iter: Box<dyn Iterator<Item = char>> = match source_iter {
+            Some(iter) => iter,
+            None => {
+                let port_path = port_path.ok_or("no port path provided")?;
                 // See https://www.enedis.fr/sites/default/files/Enedis-NOI-CPT_54E.pdf
                 // 5.3.5. Couche physique — Page : 12/38
-                let mut uart = Uart::with_path(Path::new(&port_path), 1_200, Parity::Even, 7, 1).unwrap();
-                uart.set_read_mode(1, Duration::default()).unwrap();
-                Some(Box::new(LinkyIterator { uart, buffer: [0u8] }))
-            })
-            .expect("no source provided");
+                let mut uart = Uart::with_path(Path::new(&port_path), 1_200, Parity::Even, 7, 1)?;
+                uart.set_read_mode(1, Duration::default())?;
+                Box::new(LinkyIterator { uart, buffer: [0u8] })
+            }
+        };
         // TIC mode Historique (vs. new Standard mode)
         // < LF > (0x0A) | Etiquette | < HT > (0x09) | Donnée | < HT > (0x09) | Checksum | < CR > (0x0D)
         // See https://www.enedis.fr/sites/default/files/Enedis-NOI-CPT_54E.pdf
@@ -217,6 +218,14 @@ mod tests {
             hchp: 43_280_553,
             timestamp: now,
         }
+    }
+
+    #[test]
+    fn build_returns_err_when_uart_path_invalid() {
+        let result = Linky::builder()
+            .with_port_path("/dev/nonexistent-uart-for-test".to_string())
+            .build();
+        assert!(result.is_err(), "expected Err from invalid UART path, got Ok");
     }
 
     #[test]

--- a/src/driver/rpict.rs
+++ b/src/driver/rpict.rs
@@ -120,14 +120,15 @@ impl Rpict {
             source_iter,
             dt_gen,
         } = self;
-        let source_iter = source_iter
-            .or_else(|| {
-                let port_path = port_path.expect("no port path provided");
-                let mut uart = Uart::with_path(Path::new(&port_path), 38_400, Parity::None, 8, 1).unwrap();
-                uart.set_read_mode(1, Duration::default()).unwrap();
-                Some(Box::new(RpictIterator { uart, buffer: [0u8] }))
-            })
-            .expect("no source provided");
+        let source_iter: Box<dyn Iterator<Item = char>> = match source_iter {
+            Some(iter) => iter,
+            None => {
+                let port_path = port_path.ok_or("no port path provided")?;
+                let mut uart = Uart::with_path(Path::new(&port_path), 38_400, Parity::None, 8, 1)?;
+                uart.set_read_mode(1, Duration::default())?;
+                Box::new(RpictIterator { uart, buffer: [0u8] })
+            }
+        };
         let iter = source_iter
             //.skip_while(|c| future::ready(c != '\n'))
             .scan(String::new(), |buffer, c| {
@@ -178,6 +179,14 @@ mod tests {
             l3_power_factor: 0.509,
             timestamp: now,
         }
+    }
+
+    #[test]
+    fn build_returns_err_when_uart_path_invalid() {
+        let result = Rpict::builder()
+            .with_port_path("/dev/nonexistent-uart-for-test".to_string())
+            .build();
+        assert!(result.is_err(), "expected Err from invalid UART path, got Ok");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Extract the connect/iterate/retry pattern from `LinkyActor` and `RpictActor` into a generic `actor::blocking::run_blocking_actor` helper. Exponential backoff capped at 60s, reset after any frame is produced, clean exit when all subscribers drop.
- Wire `Linky` and `Rpict` actors through the helper so a temporarily unavailable serial port no longer permanently silences the broadcast channel.
- Replace `.unwrap()` / `.expect()` in `Linky::build()` and `Rpict::build()` UART setup with `?` so failures surface as `Err` and feed into the reconnect loop instead of killing the `spawn_blocking` task.

## Test plan

- [x] `cross check --target arm-unknown-linux-gnueabi` clean
- [x] `cross clippy --target arm-unknown-linux-gnueabi --all-targets` clean for changed files (`service/influxdb.rs` warnings are pre-existing on master)
- [x] `cross test --target arm-unknown-linux-gnueabi` — 35/35 pass, including 6 new tests in `actor::blocking::tests` covering backoff, reset, empty-iter retry, subscriber-drop exit, and 2 new tests in `driver::{linky,rpict}::tests` covering invalid UART path returning `Err`
- [ ] Manual: unplug/replug serial cable on the Pi and confirm `Disconnected` → `Connected` cycle in logs without restarting the service